### PR TITLE
Rearranged Code for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+*.pyo
+__pycache__/

--- a/TimedInput.py
+++ b/TimedInput.py
@@ -2,7 +2,7 @@ import os
 import signal
 import sys
 from select import select
-import threading
+from threading import Timer
 
 
 def isWindows():
@@ -52,7 +52,7 @@ def _startThread(seconds):
     def thread_target():
         os.kill(pid, signal.SIGTERM)
 
-    t = threading.Timer(seconds, thread_target)
+    t = Timer(seconds, thread_target)
     t.start()
     return t
 

--- a/TimedInput.py
+++ b/TimedInput.py
@@ -17,7 +17,7 @@ if isWindows():
 
 
 def timed_input(seconds, prompt='', default=None):
-    """
+    """\
     This function takes a number of seconds, an optional prompt, and
     an optional default and then prints the prompt and waits
     for the user to give keyboard input for `seconds` seconds.
@@ -58,7 +58,7 @@ def _startThread(seconds):
 
 
 def _windows_timed_input(seconds, prompt='', default=None):
-    """
+    """\
     This function should not be called directly,
     it is a platform dependant implementation
 
@@ -94,7 +94,7 @@ def _windows_timed_input(seconds, prompt='', default=None):
 
 
 def _unix_timed_input(seconds, prompt='', default=None):
-    """
+    """\
     This function should not be called directly,
     it is a platform dependant implementation
 

--- a/TimedInput.py
+++ b/TimedInput.py
@@ -5,7 +5,15 @@ from select import select
 import threading
 
 
-_timed_input_0_3_0_initialized = False
+def isWindows():
+    return 'win' in sys.platform
+
+
+if isWindows():
+    def term_handler(s, f):
+        raise _InputTimeoutError()
+
+    signal.signal(signal.SIGTERM, term_handler)
 
 
 def timed_input(seconds, prompt='', default=None):
@@ -28,7 +36,7 @@ def timed_input(seconds, prompt='', default=None):
     On other platforms, select() is used and no signal handlers are
     specially installed
     """
-    if 'win' in sys.platform:
+    if isWindows():
         return _windows_timed_input(seconds, prompt, default)
     else:
         return _unix_timed_input(seconds, prompt, default)
@@ -72,16 +80,6 @@ def _windows_timed_input(seconds, prompt='', default=None):
     files (stdin) so this is the alternative approach when select is
     not available
     """
-
-    global _timed_input_0_3_0_initialized
-    if not _timed_input_0_3_0_initialized:
-
-        def term_handler(s, f):
-            raise _InputTimeoutError()
-
-        signal.signal(signal.SIGTERM, term_handler)
-
-        _timed_input_0_3_0_initialized = True
 
     try:
         print('WARNING: Input times out after {} seconds'.format(seconds))


### PR DESCRIPTION
Moved the extra signal handler set up code for Windows out of the function and to the beginning of the file. The code is still guarded by an `if isWindows()` statement so that on non-Windows platforms, it doesn't mess with the signal handlers 